### PR TITLE
Fix invalid group showing on Kanban card

### DIFF
--- a/inc/task.class.php
+++ b/inc/task.class.php
@@ -1385,6 +1385,9 @@ class PluginTasklistsTask extends CommonDBTM {
                             ]);
          foreach ($it as $data) {
             $items_id = $data[$itemtype::getForeignKeyField()];
+            if ($items_id <= 0) {
+               continue;
+            }
             $member   = [
                'itemtype'     => $itemtype,
                'items_id'     => $items_id,


### PR DESCRIPTION
If the `groups_id` field for a task is set to 0, it will show up on the Kanban as an invalid group. This PR will prevent adding the user or group if their IDs are 0 (not assigned).